### PR TITLE
Fix: SimpleSecurityHandler issue

### DIFF
--- a/onvif-java/src/test/java/org/onvif/client/AuthTest.java
+++ b/onvif-java/src/test/java/org/onvif/client/AuthTest.java
@@ -1,0 +1,40 @@
+package org.onvif.client;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+public class AuthTest {
+
+    public static void main(String[] args) throws Exception {
+
+        String date = "2024-03-06T06:04:30Z";
+        String nonce = "gHV4Y/cV8KE7OSY7+qGv0g==";
+        String password = "abcd1234";
+
+        try {
+            // 1. Base64 decode the nonce
+            byte[] decodedNonce = Base64.getDecoder().decode(nonce);
+
+            // 2. Concatenate decodedNonce, date, and password
+            byte[] dateBytes = date.getBytes();
+            byte[] passwordBytes = password.getBytes();
+            byte[] toBeHashed = new byte[decodedNonce.length + dateBytes.length + passwordBytes.length];
+
+            System.arraycopy(decodedNonce, 0, toBeHashed, 0, decodedNonce.length);
+            System.arraycopy(dateBytes, 0, toBeHashed, decodedNonce.length, dateBytes.length);
+            System.arraycopy(passwordBytes, 0, toBeHashed, decodedNonce.length + dateBytes.length, passwordBytes.length);
+
+            // 3. SHA-1 hash the concatenated bytes
+            MessageDigest digest = MessageDigest.getInstance("SHA-1");
+            byte[] sha1Hash = digest.digest(toBeHashed);
+
+            // 4. Base64 encode the SHA-1 hash
+            String digestBase64 = Base64.getEncoder().encodeToString(sha1Hash);
+
+            System.out.println("Digest: " + digestBase64);
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/onvif-java/src/test/java/org/onvif/client/Base64Test.java
+++ b/onvif-java/src/test/java/org/onvif/client/Base64Test.java
@@ -1,0 +1,28 @@
+package org.onvif.client;
+
+import java.util.Base64;
+
+public class Base64Test {
+
+
+    public static void main(String[] args) {
+        String base64String = "4AUTXXJ214OBnsdeYBXatQ==";
+
+        // decode Base64
+        byte[] decodedBytes = Base64.getDecoder().decode(base64String);
+
+        // turn byte[] to hex
+        StringBuilder hexStringBuilder = new StringBuilder();
+        for (byte b : decodedBytes) {
+            String hex = Integer.toHexString(0xff & b);
+            if (hex.length() == 1) {
+                hexStringBuilder.append('0');
+            }
+            hexStringBuilder.append(hex);
+        }
+        String hexString = hexStringBuilder.toString();
+
+        System.out.println("hex：" + hexString);
+    }
+
+}


### PR DESCRIPTION
According to the current Onvif standard, the authentication method for ws-username token requires generating a different nonce each time to pass the device's authorization check. 
In the original code, nonce generation was only executed once in the constructor, causing Onvif devices to reject authorization, as they would perceive the combination of this nonce and time as being repeatedly used within a short period. 
Therefore, I modified it to generate a new byte[16] nonce every time handleMessage is entered (it is worth noting that the original nonce was an int, for absolute accuracy, I referred to the Onvif documentation and changed it to a byte[16] to replace the original int), and then use this nonce to generate the digest.